### PR TITLE
CLOSES #27: Adds calendar PHP extension

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -16,6 +16,8 @@ $ make clean-all
 
 Build all supported image variants.
 
+**Note:** If you have set `COMPOSER_AUTH` in your environment the build may fail at the "Building run wrapper" step with the error `File name too long`. If this is the case you should simply unset the environment variable for the current session before building. i.e. `$ unset COMPOSER_AUTH`.
+
 ```
 $ make build-all
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ Summary of release changes.
 
 ### 1.0.3 - Unreleased
 
+- Adds the calendar PHP extension.
 - Adds the soap PHP extension.
+- Adds note on known issue with building when `COMPOSER_AUTH` is in use.
 - Composer [1.8.6](https://github.com/composer/composer/releases/tag/1.8.6).
 - PHP versions: 5.6.40, 7.0.33, 7.1.33, 7.2.27.
 

--- a/php56/Dockerfile
+++ b/php56/Dockerfile
@@ -73,6 +73,7 @@ RUN \
 			--with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install \
 		bcmath \
+		calendar \
 		gd \
 		opcache \
 		zip \

--- a/php70/Dockerfile
+++ b/php70/Dockerfile
@@ -74,6 +74,7 @@ RUN \
 			--with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install \
 		bcmath \
+		calendar \
 		gd \
 		opcache \
 		zip \

--- a/php71/Dockerfile
+++ b/php71/Dockerfile
@@ -74,6 +74,7 @@ RUN \
 			--with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install \
 		bcmath \
+		calendar \
 		gd \
 		opcache \
 		zip \

--- a/php72/Dockerfile
+++ b/php72/Dockerfile
@@ -74,6 +74,7 @@ RUN \
 			--with-jpeg-dir=/usr/include/ \
 	&& docker-php-ext-install \
 		bcmath \
+		calendar \
 		gd \
 		opcache \
 		zip \


### PR DESCRIPTION
CLOSES #27 

- Adds calendar PHP extension
- Adds note on known issue with building when `COMPOSER_AUTH` is in use.